### PR TITLE
Fix a typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Container Compliance
 
-Resources and tools to assert compliance of containers (docker, rocker, ...).
+Resources and tools to assert compliance of containers (docker, rocket, ...).
 
 ## Scanning Docker image using OpenSCAP
 


### PR DESCRIPTION
The container format is called rocket, not rocker.

Even though there _is_ something called [rocker](http://blog.revolutionanalytics.com/2014/10/rocker-docker-containers-for-r.html) which is related to containers I still think you meant the [rocket](https://github.com/coreos/rocket) container format. :)
