### PR TITLE
Let the PATH decide where to pick binaries

### DIFF
--- a/docker-oscap
+++ b/docker-oscap
@@ -16,7 +16,7 @@ function docker_mount_image(){
 	local target_dir=$2
 	local tmp=`mktemp -d docker.XXXXXX`
 	# -- 'docker mount' will be hopefully comming later to docker
-	/usr/bin/docker save $image_name | tar x --directory $tmp
+	docker save $image_name | tar x --directory $tmp
 	# layers now in the working directory
 	for layer in `find $tmp/* -maxdepth 1 -type d`; do
 		if tar tvf $layer/layer.tar | grep . > /dev/null; then
@@ -33,7 +33,7 @@ function docker_umount_image(){
 
 function docker_container_pid(){
 	local container_name="$1"
-	/usr/bin/docker inspect --format '{{.State.Pid}}' $container_name
+	docker inspect --format '{{.State.Pid}}' $container_name
 }
 
 function docker_container_root(){
@@ -56,7 +56,7 @@ function oscap_chroot(){
 	export OSCAP_PROBE_OS_VERSION=`uname --kernel-release`
 	export OSCAP_PROBE_ARCHITECTURE=`uname --hardware-platform`
 	export OSCAP_PROBE_PRIMARY_HOST_NAME="docker-$target-$image"
-	/usr/bin/oscap $oscap_arguments
+	oscap $oscap_arguments
 }
 
 function query_cpe_in_chroot(){


### PR DESCRIPTION
OK, this is not the best solution, but it's a first workaround to discuss that.

Problem is : calling the `docker` and `oscap` binaries is done with a full path.
This full path depends a lot on the context where you are executing.
So this path can change and make the script unusable.

I propose to let the script's interpretator to use its PATH to find them out, making it portable.
In terms of security, I understand this is not the best solution, it's a compromise.

If you want to achieve complete security, we can :
- Make all the binaries call in full path (not only docker and oscap, but also mktemp, wget, etc.)
- Make them all configurable with combination of env. variables and default variable bash notation.

What do you think ?

[ My use case is that one : https://github.com/dduportal-dockerfiles/oscap4docker, running docker-oscap inside a container to follow the transparent hypervisor principle and not having to manage dependency of hell at host level. If you want me to propose this contribution to your repository, do not hesitate ! ]
