### PR TITLE
Replace richxsl/rhel7 with offficial rhel7 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Tested on Fedora host.
   ```
   # yum install openscap-scanner docker-io
   # service docker start
-  # docker pull richxsl/rhel7
-  # oscap-docker image-cve richxsl/rhel7 \
+  # docker pull docker.io/rhel7
+  # oscap-docker image-cve docker.io/rhel7 \
       --results oval.xml --report rhel7.html
   $ firefox rhel7.html
   ```


### PR DESCRIPTION
docker.io use redhat as endpoint

$ docker pull docker.io/rhel7 | cat
Trying to pull repository docker.io/rhel7 ...
275be1d3d070: Pulling image (latest) from docker.io/rhel7
275be1d3d070: Pulling image (latest) from docker.io/rhel7, endpoint: https://registry.access.redhat.com/v1/
275be1d3d070: Pulling dependent layers
275be1d3d070: Download complete
